### PR TITLE
ux: exit p2pool if daemon didnt start

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -748,6 +748,12 @@ ApplicationWindow {
         currentWallet.startRefresh();
         informationPopup.title = qsTr("Daemon failed to start") + translationManager.emptyString;
         informationPopup.text  = error + ".\n\n" + qsTr("Please check your wallet and daemon log for errors. You can also try to start %1 manually.").arg((isWindows)? "monerod.exe" : "monerod")
+        if (middlePanel.advancedView.miningView.stopMiningEnabled == true) {
+            walletManager.stopMining()
+            p2poolManager.exit()
+            middlePanel.advancedView.miningView.update()
+            informationPopup.text += qsTr("\n\nExiting p2pool. Please check that port 18083 is available.") + translationManager.emptyString;
+        }
         informationPopup.icon  = StandardIcon.Critical
         informationPopup.onCloseCallback = null
         informationPopup.open();

--- a/pages/Mining.qml
+++ b/pages/Mining.qml
@@ -42,6 +42,7 @@ Rectangle {
     property double currentHashRate: 0
     property int threads: idealThreadCount / 2
     property alias stopMiningEnabled: stopSoloMinerButton.enabled
+    property string args: ""
     ColumnLayout {
         id: mainLayout
         Layout.fillWidth: true
@@ -293,7 +294,7 @@ Rectangle {
                                 var success;
                                 if (persistentSettings.allow_p2pool_mining) {
                                     if (p2poolManager.isInstalled()) {
-                                        var args = daemonManager.getArgs(persistentSettings.blockchainDataDir) //updates arguments
+                                        args = daemonManager.getArgs(persistentSettings.blockchainDataDir) //updates arguments
                                         if (persistentSettings.allowRemoteNodeMining || (args.includes("--zmq-pub tcp://127.0.0.1:18083") || args.includes("--zmq-pub=tcp://127.0.0.1:18083")) && args.includes("--disable-dns-checkpoints") && !args.includes("--no-zmq")) {
                                             startP2Pool()
                                         }
@@ -592,15 +593,13 @@ Rectangle {
 
     function startP2PoolLocal() {
         var noSync = false;
-        var customDaemonArgs = daemonManager.getArgs(persistentSettings.blockchainDataDir);
         //these args will be deleted because DaemonManager::start will re-add them later.
         //--no-zmq must be deleted. removing '--zmq-pub=tcp...' lets us blindly add '--zmq-pub tcp...' later without risking duplication.
         var defaultArgs = ["--detach","--data-dir","--bootstrap-daemon-address","--prune-blockchain","--no-sync","--check-updates","--non-interactive","--max-concurrency","--no-zmq","--zmq-pub=tcp://127.0.0.1:18083"]
-        var customDaemonArgsArray = customDaemonArgs.split(' ');
+        var customDaemonArgsArray = args.split(' ');
         var flag = "";
         var allArgs = [];
         var p2poolArgs = ["--zmq-pub tcp://127.0.0.1:18083","--disable-dns-checkpoints"];
-        var daemonArgs = "";
         //create an array (allArgs) of ['--arg value','--arg2','--arg3']
         for (let i = 0; i < customDaemonArgsArray.length; i++) {
             if(!customDaemonArgsArray[i].startsWith("--")) {

--- a/pages/Mining.qml
+++ b/pages/Mining.qml
@@ -41,7 +41,7 @@ Rectangle {
     property alias miningHeight: mainLayout.height
     property double currentHashRate: 0
     property int threads: idealThreadCount / 2
-
+    property alias stopMiningEnabled: stopSoloMinerButton.enabled
     ColumnLayout {
         id: mainLayout
         Layout.fillWidth: true

--- a/pages/Mining.qml
+++ b/pages/Mining.qml
@@ -295,13 +295,13 @@ Rectangle {
                                 if (persistentSettings.allow_p2pool_mining) {
                                     if (p2poolManager.isInstalled()) {
                                         args = daemonManager.getArgs(persistentSettings.blockchainDataDir) //updates arguments
-                                        if (persistentSettings.allowRemoteNodeMining || (args.includes("--zmq-pub tcp://127.0.0.1:18083") || args.includes("--zmq-pub=tcp://127.0.0.1:18083")) && args.includes("--disable-dns-checkpoints") && !args.includes("--no-zmq")) {
+                                        if (persistentSettings.allowRemoteNodeMining || (args.includes("--zmq-pub tcp://127.0.0.1:18083") || args.includes("--zmq-pub=tcp://127.0.0.1:18083")) && !args.includes("--no-zmq")) {
                                             startP2Pool()
                                         }
                                         else {
                                             var underSystemd = daemonManager.checkUnderSystemd();
                                             if (underSystemd) {
-                                                miningError(qsTr("Monerod is managed by Systemd. Manually add --zmq-pub tcp://127.0.0.1:18083 --disable-dns-checkpoints to the unit file <br>") + translationManager.emptyString)
+                                                miningError(qsTr("Monerod is managed by Systemd. Manually add --zmq-pub tcp://127.0.0.1:18083 to the unit file <br>") + translationManager.emptyString)
                                             }
                                             else {
                                                 daemonManager.stopAsync(persistentSettings.nettype, persistentSettings.blockchainDataDir, startP2PoolLocal)
@@ -599,7 +599,7 @@ Rectangle {
         var customDaemonArgsArray = args.split(' ');
         var flag = "";
         var allArgs = [];
-        var p2poolArgs = ["--zmq-pub tcp://127.0.0.1:18083","--disable-dns-checkpoints"];
+        var p2poolArgs = ["--zmq-pub tcp://127.0.0.1:18083"];
         //create an array (allArgs) of ['--arg value','--arg2','--arg3']
         for (let i = 0; i < customDaemonArgsArray.length; i++) {
             if(!customDaemonArgsArray[i].startsWith("--")) {


### PR DESCRIPTION
If port 18083 is taken. when we restart daemon it will fail (after 120 seconds, the video has a 30 sec timeout) but, p2pool will live on (spamming rpc_info for eternity) this PR piggy-backs off of the 'daemon failure to start' screen and exits p2pool there (if 'stop mining button' is enabled) - seems simple and effective. this method has not been reviewed yet. (skip to 30~ seconds)
<details>
<summary> Video </summary>

[Screencast from 30-12-22 02:28:33.webm](https://user-images.githubusercontent.com/77655812/210029490-8a987271-ba19-49bd-93bb-5e48d5b28c33.webm)

</details>
